### PR TITLE
Check, Clean and Document (CCD) of the Fibre Switch and Laser Switch codes

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
-# Sepia
-SEPIA_DLL_PATH = "C:\Users\LocalAdmin\Desktop\Pysepia\Sepia2_Lib.dll"
-SEPIA_STR_BUFFER_SIZE = 128 # min 64bytes
+# SEPIA
+SEPIA_DLL_PATH        = "C:\Users\LocalAdmin\Desktop\Pysepia\Sepia2_Lib.dll"
+SEPIA_STR_BUFFER_SIZE = 128  # must be at minimum = 64 bytes
 
 # Server
 PORT = 5020
@@ -8,8 +8,12 @@ PORT = 5020
 # Fibre Switch 
 FIBRE_SWITCH_SERIAL_PORT = 0
 FIBRE_SWITCH_BAUD_RATE   = 57600
-FIBRE_SWITCH_WAIT_TIME   = 0.1 #s
+FIBRE_SWITCH_WAIT_TIME   = 0.1  # in seconds
 
-#interlock
-INTERLOCK_PORT = 3 # =COM4
+# Interlock
+INTERLOCK_PORT      = 3  # = COM4
 INTERLOCK_BAUD_RATE = 57600
+
+# Laser Switch
+RELAY_COM_CHANNEL = 1
+RELAY_SLEEP       = 30  # in seconds

--- a/smellie/fibre_switch.py
+++ b/smellie/fibre_switch.py
@@ -3,83 +3,84 @@ from serial import Serial
 from time import sleep
 
 """
-Control of the fibre switch hardware
+Control of the Fibre Switch hardware
 """
 
-class FiberSwitchLogicError(Exception):
+class FibreSwitchLogicError(Exception):
     """
-    Thrown on inconsistencies noticed *before* any directions to the hardware
-    """
-    pass
-
-class FiberSwitchHWError(Exception):
-    """
-    Thrown *after* a hardware instruction is exectued, if a discrepancy is detected
+    Thrown if an inconsistency is noticed *before* any instructions are sent to the hardware (i.e. a problem with code logic)
     """
     pass
 
-def global_channel_number(in_chan, out_chan):
-    '''
-    Convert an (input channel, output channel) to a global channelID
-    '''
-    return (input_channel - 1) * 14 + out_chan    
+class FibreSwitchHWError(Exception):
+    """
+    Thrown if an inconsistency is noticed *after* any hardware instruction is executed (i.e. a problem with the hardware itself)
+    """
+    pass
 
-def check_channel(channel_num):
+def find_global_channel_number(in_chan, out_chan):
     '''
-    Fibre switch is limited to 70 channels input =  [1, 5], output = [1, 14]
+    Convert a specific combination of (input channel, output channel) into a global Fibre Switch channel number
 
-    :param channel_num: The channel number to check
+    :returns: global channel
+    :type global channel: int
+    '''
+    return ((in_chan - 1) * 14) + out_chan
 
-    :raises: :class:`.FiberSwitchLogicError` if the channel is unphysical
+def check_global_channel_number(channel_num):
+    '''
+    Check the validity of the desired global Fibre Switch channel number, which must be at most = 70 (input channel = [1, 5], output channel = [1, 14])
+
+    :param channel_num: the global channel number to check
+
+    :raises: :class:`.FibreSwitchLogicError` if the channel is unphysical, i.e. not between 1 and 70
     '''
     if not channel_num in xrange(70):
-        raise FiberSwitchLogicError("Invalid Fibre Switch channel {0} requested, must be 1-70 or input = 1-5 output = 1-14")
+        raise FibreSwitchLogicError("Invalid Fibre Switch channel {0} requested ... must be 1 - 70, or input = 1 - 5 and output = 1 - 14")
 
 
 class FibreSwitch(object):
     '''
-    Controlles the fibre switch via commands sent down a serial port.
-    Port and baud rate are set in config.py
+    Controls the Fibre Switch via commands sent down a serial port.
+    The port number and baud rate are set in config.py .
     '''
     def __init__(self):
         self.channel_num = None
-        self.serial      = Serial()
+        self.serial = Serial()
         self.serial.port = FIBRE_SWITCH_SERIAL_PORT
         self.serial.baudrate = FIBRE_SWITCH_BAUD_RATE
 
     def execute_message(self, msg):
         r"""
-        Send a command message over the serial port, followed by \\r\\n
-        to exectute (so you do not need to add this)
+        Send a command message over the serial port for the Fibre Switch to execute.  The message is automatically followed by \\r\\n , so you do not need to add this.
 
         :param msg:
         :type msg: string
         """
         self.serial.open()
         self.serial.write(msg)
-        self.serial.write("\r\n") # executes previous command
+        self.serial.write("\r\n")
         self.serial.close()
 
-    def set_channel(self, channel_num):
+    def set_global_channel_number(self, channel_num):
         """
-        Set the fibre switch channel, and check that it suceeded
+        Set the global Fibre Switch channel, and check that it succeeded
 
-        :param channel_num: requested new channel 
+        :param channel_num: requested new global channel number
 
-        :raises: :class:`.FiberSwitchLogicError`: if the channel is unphysical
-        :raises: :class:`.FiberSwitchHWError` if the command is unsucessful
+        :raises: :class:`.FibreSwitchLogicError`: if the requested global channel number is unphysical
+
+        :raises: :class:`.FibreSwitchHWError` if the command is unsuccessful
         """
-
-        check_channel(channel_num)
+        check_global_channel_number(channel_num)
         self.channel_num = channel_num
         self.execute_message("ch{0}".format(channel_num))
-        if(get_channel() != channel_num):
-            raise FiberSwitchHWError("Failed to set fibre switch to {0}".format(channel_num))
+        if(get_global_channel_number() != channel_num):
+            raise FiberSwitchHWError("Failed to set Fibre Switch to {0}".format(channel_num))
 
     def read_back(self):
         """
-        Wait a configuration determined time, and read back a line 
-        from the HW
+        Wait for a configuration-determined time, and read back a line from the hardware
 
         :returns: message
         :type message: string
@@ -87,9 +88,9 @@ class FibreSwitch(object):
         sleep(FIBRE_SWITCH_WAIT_TIME)
         return self.serial.readline()
 
-    def get_channel(self):
+    def get_global_channel_number(self):
         """
-        Poll the hardware for the current channel
+        Poll the Fibre Switch for the current global channel number
 
         :returns: current channel
         :type current channel: int
@@ -97,30 +98,30 @@ class FibreSwitch(object):
         self.execute_message("ch?")
         return self.read_back()
 
-    def set_io_channels(self, in_channel, out_channel):
+    def set_io_channel_numbers(self, in_channel, out_channel):
         """
-        Set the channel number using an input and output channel
+        Set the global Fibre Switch channel number using explicit input and output channels
 
-        :param in_channel: Input
-        :param out_channel: Output
+        :param in_channel: requested input channel
+        :param out_channel: requested output channel
         
-        :raises: :class:`.FiberSwitchLogicError` if channel is unphysical
+        :raises: :class:`.FibreSwitchLogicError` if the requested global channel number is unphysical
 
-        :raises: :class:`.FiberSwitchHWError` if the command is unsucessful
+        :raises: :class:`.FibreSwitchHWError` if the command is unsuccessful
         """
-        set_channel(global_channel_number(in_channel, out_channel))
+        set_global_channel_number(find_global_channel_number(in_channel, out_channel))
         
     def get_fwr_version(self):
         """
-        Get the current fwr version as a string
+        Get the current Fibre Switch firmware version as a string
         """
         self.execute_message("firmware?")
         return self.read_back()    
 
     def current_state(self):
         """
-        Returns a formatted string with the current harware settings
+        Return a formatted string with the current hardware settings
         """
         return """Firmware version : {0}
-Fiber Switch Channel : {1}
-""".format(get_channel(), get_fwr_version())
+Fibre Switch channel : {1}
+""".format(get_global_channel_number(), get_fwr_version())

--- a/smellie/laser_switch.py
+++ b/smellie/laser_switch.py
@@ -1,65 +1,114 @@
-COM_CHANNEL = 1
-RELAY_SLEEP = 30
+from config import RELAY_COM_CHANNEL, RELAY_SLEEP
 from time import sleep
 
+"""
+Control of the Laser Switch hardware
+"""
+
 def invert(bit):
+    '''
+    Invert the input bit, i.e. convert 0 to 1, or 1 to 0
+
+    :param bit: the input bit
+    '''
     if bit in (0, 1):
         return (not bit)
-    raise TypeError("Invert bit - not a boolean!")
+    raise TypeError("Cannot invert bit - not a boolean!")
 
 def translate_bits_big_endian(b1, b2, b3):
+    '''
+    Convert a binary value into a sequence of bytes, according to big-endian ordering
+    '''
     return int("{2}{1}{0}".format(b1, b2, b3), 2)
 
 class LaserSwitchLogicError(Exception):
+    """
+    Thrown if an inconsistency is noticed *before* any instructions are sent to the hardware (i.e. a problem with code logic)
+    """
     pass
 
 class LaserSwitchHWError(Exception):
+    """
+    Thrown if an inconsistency is noticed *after* any hardware instruction is executed (i.e. a problem with the hardware itself)
+    """
     pass
 
 class LaserSwitch(object):
-    def __init__(channel):
-        self.com_channel = COM_CHANNEL
+    '''
+    Controls the Laser Switch via commands sent down a USB port.
+    The port number is set in config.py .
+    '''
+    def __init__(self):
+        self.com_channel = RELAY_COM_CHANNEL
         self.connection = U12()
 
-    def channel_up(self):
-        orig = get_selected_channel()
+    def selected_channel_up(self):
+        """
+        Increment the currently selected Laser Switch channel by + 1
+
+        :raises: :class:`.LaserSwitchHWError` if the command is unsuccessful
+        """
+        original_channel = get_selected_channel()
         self.connection.eDigitalOut(self.com_channel, 1, writeD = 1) 
         self.connection.eDigitalOut(self.com_channel, 0, writeD = 1) 
         self.connection.eDigitalOut(self.com_channel, 1, writeD = 1) 
-        if 1 + orig != get_selected_channel():
-            raise LaserSwitchHWError("channel_up call failed!")
+        if (1 + original_channel) != get_selected_channel():
+            raise LaserSwitchHWError("Failed to increment the selected Laser Switch channel number!")
 
     def execute(self):
+        """
+        Change the active Laser Switch channel from the currently active one to the currently selected one
+        """
         self.connection.eDigitalOut(0, 1, writeD = 1) 
         self.connection.eDigitalOut(0, 0, writeD = 1) 
         self.connection.eDigitalOut(0, 1, writeD = 1)
         sleep(RELAY_SLEEP)
         
     def get_selected_channel(self):
+        """
+        Poll the Laser Switch for the current selected channel, i.e. the one which will become "active" with the next "execute" command
+
+        :returns: selected channel
+        :type selected channel: int
+        """
         return translate_bits_big_endian(self.connection.eDigitalIn(2),
                                          self.connection.eDigitalIn(3),
-                                         self.connection.eDigitalIn(4),
-                                         )
+                                         self.connection.eDigitalIn(4))
 
     def get_active_channel(self):
+        """
+        Poll the Laser Switch for the current active channel, i.e. corresponding to the currently operating laser head
+
+        :returns: active channel
+        :type active channel: int
+
+		:raises: :class:`.LaserSwitchHWError` if the command is unsuccessful
+        """
         channel = translate_bits_big_endian(self.connection.eDigitalIn(5),
                                             self.connection.eDigitalIn(6),
-                                            self.connection.eDigitalIn(7),
-                                            )
+                                            self.connection.eDigitalIn(7))
         if not channel in xrange(6):
-            raise LaserSwitchHWError("Laser switch returned unphysical channel number!")
+            raise LaserSwitchHWError("Laser Switch returned unphysical active channel number!  It should be between 0 and 5 inclusive.")
         return channel
 
-    def set_channel(self, channel):
-        if not channel in xrange(6):
-            raise LaserSwitchLogicError("Can't set display channel to {0}, must be 0-5 inclusive".format(channel))
+    def set_active_channel(self, channel):
+        """
+        Set the active Laser Switch channel - must be between 0 and 5 inclusive
         
-        while(channel != self.get_channel()):
-            self.channel_up()
-            
+        :param channel: requested active channel
+
+        :raises: :class:`.LaserSwitchLogicError` if the requested active channel number is unphysical
+        """
+        if not channel in xrange(6):
+            raise LaserSwitchLogicError("Cannot set selected Laser Switch channel to {0} - must be between 0 and 5 inclusive.".format(channel))
+        while(channel != self.get_selected_channel()):
+            self.selected_channel_up()
         self.execute()
     
     def current_state(self):
-        return """Active Channel : {0}
-Current Channel : {1}
-""".format(self.get_active_channel(), self.get_selected_channel())
+        """
+        Return a formatted string with the current hardware settings
+        """
+        return """Active channel : {0}
+Selected channel : {1}
+""".format(get_active_channel(), get_selected_channel())

--- a/smellie/smellie_controller.py
+++ b/smellie/smellie_controller.py
@@ -1,6 +1,6 @@
 from laser_driver import LaserDriver
 from laser_switch import LaserSwitch
-from fiber_switch import FibreSwitch
+from fibre_switch import FibreSwitch
 from time import sleep
 from ni_box import TriggerGenerator, GainVoltageGenerator
 import system_state
@@ -9,7 +9,7 @@ class SmellieController(object):
     def __enter__(self):
         """Open the SMELLIE CONTROLLER, hardware in deactivated mode
         """        
-        self.fiber_switch = FibreSwitch()              
+        self.fibre_switch = FibreSwitch()              
         self.laser_switch = LaserSwitch()              
         self.gain_voltage_gen = GainVoltageGenerator() 
         self.laser_driver = LaserDriver()              
@@ -32,16 +32,16 @@ class SmellieController(object):
 
     def deactivate(self):
         self.go_safe()
-        self.laser_switch.set_channel(0)
+        self.laser_switch.set_active_channel(0)
         return 0
 
     def pulse_master_mode(self, freq, n_pulses, 
                           fs_input_chan, fs_output_chan,
                           ls_chan, intensity
                           ):
-        self.laser_switch.set_channel(ls_chan)
+        self.laser_switch.set_active_channel(ls_chan)
         self.laser_driver.set_intensity(intensity)
-        self.fiber_switch.set_channel(input_channel, output_channel)
+        self.fibre_switch.set_io_channel_numbers(input_channel, output_channel)
         
         with TriggerGenerator() as trig:
             trig.generate(n_pulses)
@@ -51,9 +51,9 @@ class SmellieController(object):
 
     def enter_slave_mode(self, fs_input_chan, fs_output_chan, 
                          ls_chan, intensity, time):
-        self.laser_switch.set_channel(ls_chan)
+        self.laser_switch.set_active_channel(ls_chan)
         self.laser_driver.set_intensity(intensity)
-        self.fiber_switch.set_channel(fs_input_chan, fs_output_chan)
+        self.fibre_switch.set_io_channel_numbers(fs_input_chan, fs_output_chan)
         sleep(time)
         self.go_safe()
         return 0
@@ -84,6 +84,6 @@ GAIN CONTROL:
            system_state.get_config_str(),
            laser_driver_state,
            self.laser_switch.current_state(),
-           self.fiber_switch.current_state(),
+           self.fibre_switch.current_state(),
            self.gain_voltage_gen.current_state()
            )

--- a/smellie/system_state.py
+++ b/smellie/system_state.py
@@ -10,7 +10,7 @@ def get_SHA():
 
 def get_config_str():
     """
-    Reads the config module into a string
+    Reads the config.py module (located one folder-level up from this file) into a string
     """
     return "\n".join("{0} : {1}".format(k, v) for (k, v) in config.__dict__.iteritems() if not k.startswith("__"))
 


### PR DESCRIPTION
Have checked through the Fibre Switch and Laser Switch python scripts, correcting typos and adding in new (Laser Switch) and/or clearer (Fibre Switch) documentation.  I also changed a small number of the function names, to make it more obvious as to what they were doing (particularly when dealing with active vs. selected Laser Switch channels) - have changed the function calls both internally and in the SmellieController script accordingly.

Also, moved the Laser Switch port and sleep values to the config.py file.
